### PR TITLE
27 add explanation about when to use each likelihood

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,12 @@ Gaussian likelihood with a mean given by :math:`f(x_{\rm obs}, \theta)` and a va
 distribution of true x values and thus gives biased results. Instead, this package allows
 one to use the MNR (Marginalised Normal Regression) method which does not exhibit such 
 biases. 
+A range of likelihoods are available in ``roxy``, however we recommed you use the following one in
+these situations:
+
+- If you have :math:`x` and :math:`y` errors and DO wish to infer intrinsic scatter: use ``method='mnr'``.
+- If you have :math:`x` and :math:`y` errors and DO NOT wish to infer intrinsic scatter: use ``method='prof'``.
+- If you only have :math:`y` errors: use ``method='prof'`` or ``method='unif'`` (they are identical in this case).
 
 The code uses automatic differentiation enabled by jax to both sample the
 likelihood using Hamiltonian Monte Carlo and to compute the derivatives 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -7,10 +7,16 @@ In this tutorial we demonstrate how to fit a function to data using both a maxim
 MCMC using the ``roxy`` module. We then plot our results. 
 
 To start with, we call functions with the argument ``method='mnr'`` 
-as this is the simplest recommended likelihood for data with x and y errors, however this can be replaced with ``method='unif'`` 
+as this is the simplest recommended likelihood for data with x and y errors and if you infer intrinsic scatter, 
+however this can be replaced with ``method='unif'`` 
 for an infinite uniform prior on the true x values, or ``method='prof'`` to use the profile likelihood. 
 In the presence of x-errors, the profile method is accurate in the absence of intrinsic scatter and the 
 unif method able to recover intrinsic scatter, however MNR is the only method that is approximately unbiased in all the regression parameters.
+In summary, you should use the following likelihoods in the following situations:
+
+- If you have :math:`x` and :math:`y` errors and DO wish to infer intrinsic scatter: use ``method='mnr'``.
+- If you have :math:`x` and :math:`y` errors and DO NOT wish to infer intrinsic scatter: use ``method='prof'``.
+- If you only have :math:`y` errors: use ``method='prof'`` or ``method='unif'`` (they are identical in this case).
 
 Next, we show how to extend the MNR method to a sum of Gaussians using the argument
 ``method='gmm'``.

--- a/roxy/likelihoods.py
+++ b/roxy/likelihoods.py
@@ -24,7 +24,7 @@ def likelihood_warnings(method, infer_intrinsic, nx, errors, covmat):
     
     # Check if xerrs are all zero
     if covmat:
-        xerr = covmat[:nx,:nx]
+        xerr = errors[:nx,:nx]
     else:
         xerr = errors[0]
     if isinstance(xerr, (float, int)):
@@ -38,10 +38,10 @@ def likelihood_warnings(method, infer_intrinsic, nx, errors, covmat):
         warning_message = (
             f'Not recommended method "{method}" for this setup. '
             'Use "unif" or "prof" instead.')
-    elif (not no_xerr) and infer_intrinsic and method != 'mnr':
+    elif (not no_xerr) and infer_intrinsic and method not in ['mnr', 'gmm']:
         warning_message = (
             f'Not recommended method "{method}" for this setup. '
-            'Use "mnr" instead.')
+            'Use "mnr" or "gmm" instead.')
     elif (not no_xerr) and (not infer_intrinsic) and method != 'prof':
         warning_message = (
             f'Not recommended method "{method}" for this setup. '

--- a/roxy/likelihoods.py
+++ b/roxy/likelihoods.py
@@ -1,4 +1,56 @@
 import jax.numpy as jnp
+import warnings
+
+def likelihood_warnings(method, infer_intrinsic, nx, errors, covmat):
+    """
+    Raise warnings if using asymptotically biased likelihood
+    for the situation of interest.
+    
+    Args:
+        :method (str, default='mnr'): The name of the likelihood method to use
+                ('mnr', 'gmm', 'unif' or 'prof').
+        :infer_intrinsic (bool, default=True): Whether to infer the intrinsic
+                scatter in the y direction
+        :nx (int): The number of observed x values
+        :errors (jnp.ndarray): If covmat=False, then this is [xerr, yerr], giving
+                the error on the observed x and y values. Otherwise, this is the
+                covariance matrix in the order (x, y)
+        :covmat (bool, default=False): This determines whether the errors argument
+                is [xerr, yerr] (False) or a covariance matrix (True).
+    """
+    
+    # Modify the warnings filter to always show all warnings
+    warnings.filterwarnings('always')
+    
+    # Check if xerrs are all zero
+    if covmat:
+        xerr = covmat[:nx,:nx]
+    else:
+        xerr = errors[0]
+    if isinstance(xerr, (float, int)):
+        no_xerr = (xerr == 0)
+    else:
+        no_xerr = jnp.all(jnp.array(xerr) == 0)
+        
+    warning_message = None
+    
+    if no_xerr and method not in ['unif', 'prof']:
+        warning_message = (
+            f'Not recommended method "{method}" for this setup. '
+            'Use "unif" or "prof" instead.')
+    elif (not no_xerr) and infer_intrinsic and method != 'mnr':
+        warning_message = (
+            f'Not recommended method "{method}" for this setup. '
+            'Use "mnr" instead.')
+    elif (not no_xerr) and (not infer_intrinsic) and method != 'prof':
+        warning_message = (
+            f'Not recommended method "{method}" for this setup. '
+            'Use "prof" instead.')
+    
+    if warning_message is not None:
+        warnings.warn(warning_message, UserWarning)
+
+    return
 
 def negloglike_mnr(xobs, yobs, xerr, yerr, f, fprime, sig, mu_gauss, w_gauss):
     """

--- a/roxy/regressor.py
+++ b/roxy/regressor.py
@@ -253,6 +253,10 @@ class RoxyRegressor():
             :res (OptResult): The result of the optimisation
             :param_names (list): List of parameter names in order of res.params
         """
+        
+        # Check if warning should be raised
+        roxy.likelihoods.likelihood_warnings(
+            method, infer_intrinsic, len(xobs), errors, covmat)
     
         # Get indices of params to optimise
         pidx = self.get_param_index(params_to_opt)
@@ -480,6 +484,10 @@ class RoxyRegressor():
             :samples (dict): The MCMC samples, where the keys are the parameter names
                 and values are ndarrays of the samples
         """
+        
+        # Check if warning should be raised
+        roxy.likelihoods.likelihood_warnings(
+            method, infer_intrinsic, len(xobs), errors, covmat)
 
         pidx = self.get_param_index(params_to_opt, verbose=False)
         
@@ -844,6 +852,10 @@ class RoxyRegressor():
         
         """
         
+        # Check if warning should be raised
+        roxy.likelihoods.likelihood_warnings(
+            method, infer_intrinsic, len(xobs), errors, covmat)
+        
         if initial is None:
             # First run a MCMC to get a guess at the peak, catching the low neff warning
             with warnings.catch_warnings():
@@ -934,6 +946,10 @@ class RoxyRegressor():
             :ngauss (int): The best number of Gaussians to use according to the metric
         
         """
+        
+        # Check if warning should be raised
+        roxy.likelihoods.likelihood_warnings(
+            'gmm', infer_intrinsic, len(xobs), [xerr, yerr], False)
     
         metric = np.empty(max_ngauss)
     


### PR DESCRIPTION
In this PR we 

- Add information to the README and the tutorial to state when each likelihood should be used
- Raise warnings if the incorrect likelihood is used
- Add unit tests to ensure that these warnings are raised